### PR TITLE
Fix rounding issue when propagating order/checkout level discount on lines

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -635,11 +635,10 @@ def _set_checkout_base_prices(
 
     for line_info in lines:
         line = line_info.line
-        quantity = line.quantity
-
-        unit_price = base_calculations.calculate_base_line_unit_price(line_info)
-        total_price = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info, lines, line_info, unit_price * quantity
+        total_price = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info, lines, line_info
+            )
         )
         line_total_price = quantize_price(total_price, currency)
         subtotal += line_total_price

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -245,7 +245,10 @@ def propagate_order_discount_on_order_lines_prices(
                 share = (
                     line.base_unit_price_amount * line.quantity / base_subtotal.amount
                 )
-                discount = min(share * subtotal_discount, base_subtotal)
+                discount = quantize_price(
+                    min(share * subtotal_discount, base_subtotal),
+                    base_subtotal.currency,
+                )
                 yield (
                     line,
                     _get_total_price_with_subtotal_discount_for_order_line(
@@ -290,8 +293,7 @@ def apply_subtotal_discount_to_order_lines(
 
 
 def assign_order_line_prices(line: "OrderLine", total_price: Money):
-    currency = total_price.currency
-    line.total_price_net = quantize_price(total_price, currency)
+    line.total_price_net = total_price
     line.total_price_gross = line.total_price_net
     line.undiscounted_total_price_gross_amount = (
         line.undiscounted_total_price_net_amount

--- a/saleor/order/tests/fixtures/order.py
+++ b/saleor/order/tests/fixtures/order.py
@@ -260,6 +260,73 @@ def order_list_with_cc_orders(orders, warehouse_for_cc):
 
 
 @pytest.fixture
+def order_lines_generator():
+    def create_order_line(
+        order, variants, unit_prices, quantities, create_allocations=True
+    ):
+        channel = order.channel
+        order_lines = []
+        allocations = []
+        stocks_to_update = []
+        variant_channel_listings_map = {
+            cl.variant_id: cl
+            for cl in ProductVariantChannelListing.objects.filter(
+                variant__in=variants, channel=channel
+            )
+        }
+        for variant, price, quantity in zip(variants, unit_prices, quantities):
+            product = variant.product
+            variant_channel_listing = variant_channel_listings_map[variant.id]
+            currency = channel.currency_code
+            base_price = Money(price, currency)
+            net = Money(price, channel.currency_code)
+            gross = Money(amount=net.amount * Decimal(1.23), currency=currency)
+            unit_price = TaxedMoney(net=net, gross=gross)
+            order_line = OrderLine(
+                order=order,
+                product_name=str(product),
+                variant_name=str(variant),
+                product_sku=variant.sku,
+                product_variant_id=variant.get_global_id(),
+                is_shipping_required=variant.is_shipping_required(),
+                is_gift_card=variant.is_gift_card(),
+                quantity=quantity,
+                variant=variant,
+                unit_price=unit_price,
+                total_price=unit_price * quantity,
+                undiscounted_unit_price=unit_price,
+                undiscounted_total_price=unit_price * quantity,
+                base_unit_price=base_price,
+                undiscounted_base_unit_price=base_price,
+                tax_rate=Decimal("0.23"),
+                **get_tax_class_kwargs_for_order_line(product.product_type.tax_class),
+            )
+            order_lines.append(order_line)
+            variant_channel_listing.price_amount = price
+            variant_channel_listing.discounted_price_amount = price
+            if create_allocations:
+                stock = variant.stocks.first()
+                allocation = Allocation(
+                    order_line=order_line, stock=stock, quantity_allocated=quantity
+                )
+                allocations.append(allocation)
+                stock.quantity_allocated += quantity
+                stocks_to_update.append(stock)
+
+        OrderLine.objects.bulk_create(order_lines)
+        if allocations:
+            Allocation.objects.bulk_create(allocations)
+            Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
+        ProductVariantChannelListing.objects.bulk_update(
+            variant_channel_listings_map.values(),
+            ["price_amount", "discounted_price_amount"],
+        )
+        return order_lines
+
+    return create_order_line
+
+
+@pytest.fixture
 def order_with_lines(
     order,
     product_type,
@@ -268,6 +335,7 @@ def order_with_lines(
     warehouse,
     channel_USD,
     default_tax_class,
+    order_lines_generator,
 ):
     product = Product.objects.create(
         name="Test product",
@@ -283,47 +351,17 @@ def order_with_lines(
         visible_in_listings=True,
         available_for_purchase_at=datetime.datetime.now(tz=datetime.UTC),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_AA")
-    channel_listing = ProductVariantChannelListing.objects.create(
-        variant=variant,
+    variant_1_quantity = 3
+    variant_1 = ProductVariant.objects.create(product=product, sku="SKU_AA")
+    ProductVariantChannelListing.objects.create(
+        variant=variant_1,
         channel=channel_USD,
         price_amount=Decimal(10),
         discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
-    quantity = 3
-    stock = Stock.objects.create(
-        warehouse=warehouse,
-        product_variant=variant,
-        quantity=5,
-        quantity_allocated=quantity,
-    )
-    base_price = variant.get_price(channel_listing)
-    currency = base_price.currency
-    gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-    unit_price = TaxedMoney(net=base_price, gross=gross)
-    line = order.lines.create(
-        product_name=str(variant.product),
-        variant_name=str(variant),
-        product_sku=variant.sku,
-        product_variant_id=variant.get_global_id(),
-        is_shipping_required=variant.is_shipping_required(),
-        is_gift_card=variant.is_gift_card(),
-        quantity=quantity,
-        variant=variant,
-        unit_price=unit_price,
-        total_price=unit_price * quantity,
-        undiscounted_unit_price=unit_price,
-        undiscounted_total_price=unit_price * quantity,
-        base_unit_price=base_price,
-        undiscounted_base_unit_price=base_price,
-        tax_rate=Decimal("0.23"),
-        **get_tax_class_kwargs_for_order_line(product_type.tax_class),
-    )
-    Allocation.objects.create(
-        order_line=line, stock=stock, quantity_allocated=line.quantity
-    )
+    Stock.objects.create(warehouse=warehouse, product_variant=variant_1, quantity=5)
 
     product = Product.objects.create(
         name="Test product 2",
@@ -339,48 +377,23 @@ def order_with_lines(
         visible_in_listings=True,
         available_for_purchase_at=timezone.now(),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_B")
-    channel_listing = ProductVariantChannelListing.objects.create(
-        variant=variant,
+    variant_2 = ProductVariant.objects.create(product=product, sku="SKU_B")
+    variant_2_quantity = 2
+    ProductVariantChannelListing.objects.create(
+        variant=variant_2,
         channel=channel_USD,
         price_amount=Decimal(20),
         discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
-    quantity = 2
-    stock = Stock.objects.create(
-        product_variant=variant,
-        warehouse=warehouse,
-        quantity=2,
-        quantity_allocated=quantity,
-    )
-    stock.refresh_from_db()
+    Stock.objects.create(warehouse=warehouse, product_variant=variant_2, quantity=2)
 
-    base_price = variant.get_price(channel_listing)
-    currency = base_price.currency
-    gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-    unit_price = TaxedMoney(net=base_price, gross=gross)
-    line = order.lines.create(
-        product_name=str(variant.product),
-        variant_name=str(variant),
-        product_sku=variant.sku,
-        product_variant_id=variant.get_global_id(),
-        is_shipping_required=variant.is_shipping_required(),
-        is_gift_card=variant.is_gift_card(),
-        quantity=quantity,
-        variant=variant,
-        unit_price=unit_price,
-        total_price=unit_price * quantity,
-        undiscounted_unit_price=unit_price,
-        undiscounted_total_price=unit_price * quantity,
-        base_unit_price=base_price,
-        undiscounted_base_unit_price=base_price,
-        tax_rate=Decimal("0.23"),
-        **get_tax_class_kwargs_for_order_line(product_type.tax_class),
-    )
-    Allocation.objects.create(
-        order_line=line, stock=stock, quantity_allocated=line.quantity
+    order_lines_generator(
+        order,
+        [variant_1, variant_2],
+        [10, 20],
+        [variant_1_quantity, variant_2_quantity],
     )
 
     order.shipping_address = order.billing_address.get_copy()

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -448,15 +448,13 @@ class PluginsManager(PaymentInterface):
         address: Optional["Address"],
         plugin_ids: Optional[list[str]] = None,
     ) -> TaxedMoney:
-        default_value = base_calculations.calculate_base_line_total_price(
-            checkout_line_info,
-        )
         # apply entire order discount or discount from order promotion
-        default_value = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info,
-            lines,
-            checkout_line_info,
-            default_value,
+        default_value = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info,
+                lines,
+                checkout_line_info,
+            )
         )
         default_value = quantize_price(default_value, checkout_info.checkout.currency)
         default_taxed_value = TaxedMoney(net=default_value, gross=default_value)
@@ -525,15 +523,13 @@ class PluginsManager(PaymentInterface):
         plugin_ids: Optional[list[str]] = None,
     ) -> TaxedMoney:
         quantity = checkout_line_info.line.quantity
-        default_value = base_calculations.calculate_base_line_unit_price(
-            checkout_line_info
-        )
         # apply entire order discount
-        total_value = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info,
-            lines,
-            checkout_line_info,
-            default_value * quantity,
+        total_value = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info,
+                lines,
+                checkout_line_info,
+            )
         )
         default_taxed_value = TaxedMoney(
             net=total_value / quantity, gross=total_value / quantity

--- a/saleor/tax/calculations/checkout.py
+++ b/saleor/tax/calculations/checkout.py
@@ -102,14 +102,12 @@ def calculate_checkout_line_total(
     tax_rate: Decimal,
     prices_entered_with_tax: bool,
 ) -> TaxedMoney:
-    base_total_price = base_calculations.calculate_base_line_total_price(
-        checkout_line_info,
-    )
-    total_price = base_calculations.apply_checkout_discount_on_checkout_line(
-        checkout_info,
-        lines,
-        checkout_line_info,
-        base_total_price,
+    total_price = (
+        base_calculations.get_line_total_price_with_propagated_checkout_discount(
+            checkout_info,
+            lines,
+            checkout_line_info,
+        )
     )
     total_price = calculate_flat_rate_tax(
         total_price, tax_rate, prices_entered_with_tax

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -250,7 +250,7 @@ def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipp
 
     # then
     assert order.total == TaxedMoney(
-        net=Money("4.06", "USD"), gross=Money("5.01", "USD")
+        net=Money("4.07", "USD"), gross=Money("5.01", "USD")
     )
 
 
@@ -315,7 +315,7 @@ def test_calculations_calculate_order_total_with_manual_discount_and_voucher(
 
     # then
     assert order.total == TaxedMoney(
-        net=Money("48.78", "USD"), gross=Money("60.00", "USD")
+        net=Money("48.77", "USD"), gross=Money("60.00", "USD")
     )
 
 

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -29,6 +29,9 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       total {
         ...BaseTaxedMoney
       }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
       voucherCode
       voucher {
         id


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17024

Previously, there were cases where a 0.01 discrepancy in price could occur due to rounding issues. I added rounding to the line portion calculation, which resolves this problem.

Port of https://github.com/saleor/saleor/pull/17004

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separ...